### PR TITLE
Added support for GPIO poweroff

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ To install, run `setup.sh` and when prompted enter the pin you would you like to
 
 The setup script expects an integer value between 4 and 27 (you can use others outside this range by manually editing the config file as explained below, but there are caveats so if it does not quite work, you're on your own!)
 
+To install for a specific product, such as OnOff SHIM, run `setup.sh onoffshim` and the correct defaults will be set for you.
+
+## Supported Products
+
+* Normal install - Uses your chosen pin, no LED indication or power off support
+* OnOff SHIM - Uses BCM 17 as trigger and LED pin, and BCM 4 as the power off pin
+
 If you are unsure how to clone this repository, you can also use the following command to make your life easier:
 
 ```

--- a/README.md
+++ b/README.md
@@ -53,4 +53,20 @@ This parameter determines how often the trigger is checked for. Normally, a smal
 
 ### `trigger_pin`
 
-Normally you'll set this up at install timme and won't need to change it, but... as we do, next week you might buy a nice shiny (Pimoroni) HAT or pHAT and find that the pin you had your clean shutdown trigger wired to is required by your new friend. Just move the trigger button to another pin and reboot! The unit used for this parameter is the bcm number of the pin (4 or above recommended, 0-3 have particularities that make them slightly less straightforward to use, though the daemon will happily monitor them for you, so as long as you know what you're doing go right ahead).
+Normally you'll set this up at install time and won't need to change it, but... as we do, next week you might buy a nice shiny (Pimoroni) HAT or pHAT and find that the pin you had your clean shutdown trigger wired to is required by your new friend. Just move the trigger button to another pin and reboot! The unit used for this parameter is the bcm number of the pin (4 or above recommended, 0-3 have particularities that make them slightly less straightforward to use, though the daemon will happily monitor them for you, so as long as you know what you're doing go right ahead).
+
+### `poweroff_pin`
+
+Set up at install time for products that support it (eg: OnOff SHIM) the `poweroff_pin` determines which pin will be pulled low right at the end of your Pi's shutdown process. If supported, this will cause power to your Pi to be cut completely.
+
+* This is pin 4 on OnOff SHIM
+
+### `led_pin`
+
+Like `poweroff_pin` this is set up at install time for supported products. It determines which pin will be pulled low to blink a status LED, first showing that shutdown has been armed, and finally blinking three times to show that final power off is imminent.
+
+* This is pin 17 on OnOff SHIM
+
+### `hold_time`
+
+This parameter determines the amount of time, in seconds, you must hold down the button until shutdown occurs. It defaults to 2 seconds to avoid accidental shutdowns. Use 0 or off to shutdown as soon as the button is pressed.

--- a/daemon/etc/cleanshutd.conf
+++ b/daemon/etc/cleanshutd.conf
@@ -4,4 +4,4 @@ polling_rate=2
 trigger_pin=4
 poweroff_pin=off
 led_pin=off
-hold_time=2
+hold_time=0

--- a/daemon/etc/cleanshutd.conf
+++ b/daemon/etc/cleanshutd.conf
@@ -2,3 +2,4 @@ daemon_active=1
 shutdown_delay=0
 polling_rate=2
 trigger_pin=4
+poweroff_pin=0

--- a/daemon/etc/cleanshutd.conf
+++ b/daemon/etc/cleanshutd.conf
@@ -4,3 +4,4 @@ polling_rate=2
 trigger_pin=4
 poweroff_pin=off
 led_pin=off
+hold_time=2

--- a/daemon/etc/cleanshutd.conf
+++ b/daemon/etc/cleanshutd.conf
@@ -2,4 +2,5 @@ daemon_active=1
 shutdown_delay=0
 polling_rate=2
 trigger_pin=4
-poweroff_pin=0
+poweroff_pin=off
+led_pin=off

--- a/daemon/lib/systemd/system-shutdown/gpio-poweroff
+++ b/daemon/lib/systemd/system-shutdown/gpio-poweroff
@@ -1,0 +1,35 @@
+#! /bin/sh
+
+# file: /lib/systemd/system-shutdown/gpio-poweroff
+# $1 will be either "halt", "poweroff", "reboot" or "kexec"
+
+GPIO_PIN=0
+CONFIG_FILE=/etc/cleanshutd.conf
+
+if [ -f "$CONFIG_FILE" ]; then
+    /bin/echo "Reading config file $CONFIG_FILE"
+
+    CONFIG_PIN=`grep -r '^poweroff_pin=[0-9]*$' "$CONFIG_FILE" | cut -f2- -d=`
+
+    if [ "$CONFIG_PIN" != "" ]; then
+        GPIO_PIN=$CONFIG_PIN
+    fi
+fi
+
+if [ $GPIO_PIN -le 0 ]; then
+    /bin/echo "Skipping GPIO power-off"
+    exit 0
+fi
+
+/bin/echo "Using GPIO pin $GPIO_PIN"
+
+case "$1" in
+  poweroff)
+        /bin/echo $GPIO_PIN > /sys/class/gpio/export
+        /bin/echo out > /sys/class/gpio/gpio$GPIO_PIN/direction
+        /bin/echo 0 > /sys/class/gpio/gpio$GPIO_PIN/value
+        /bin/sleep 0.5
+        ;;
+esac
+
+:

--- a/daemon/lib/systemd/system-shutdown/gpio-poweroff
+++ b/daemon/lib/systemd/system-shutdown/gpio-poweroff
@@ -3,31 +3,46 @@
 # file: /lib/systemd/system-shutdown/gpio-poweroff
 # $1 will be either "halt", "poweroff", "reboot" or "kexec"
 
-GPIO_PIN=0
-CONFIG_FILE=/etc/cleanshutd.conf
+poweroff_pin=""
+led_pin=""
+config_file=/etc/cleanshutd.conf
 
-if [ -f "$CONFIG_FILE" ]; then
-    /bin/echo "Reading config file $CONFIG_FILE"
+if [ -f "$config_file" ]; then
+    /bin/echo "Reading config file $config_file"
 
-    CONFIG_PIN=`grep -r '^poweroff_pin=[0-9]*$' "$CONFIG_FILE" | cut -f2- -d=`
-
-    if [ "$CONFIG_PIN" != "" ]; then
-        GPIO_PIN=$CONFIG_PIN
-    fi
+    poweroff_pin=`grep -r '^poweroff_pin=[0-9]*$' "$config_file" | cut -f2- -d=`
+    led_pin=`grep -r '^led_pin=[0-9]*$' "$config_file" | cut -f2- -d=`
+ 
 fi
-
-if [ $GPIO_PIN -le 0 ]; then
-    /bin/echo "Skipping GPIO power-off"
-    exit 0
-fi
-
-/bin/echo "Using GPIO pin $GPIO_PIN"
-
 case "$1" in
   poweroff)
-        /bin/echo $GPIO_PIN > /sys/class/gpio/export
-        /bin/echo out > /sys/class/gpio/gpio$GPIO_PIN/direction
-        /bin/echo 0 > /sys/class/gpio/gpio$GPIO_PIN/value
+
+        if [ "$poweroff_pin" = "" ]; then
+            /bin/echo "Skipping GPIO power-off"
+            exit 0
+        fi
+
+        /bin/echo "Using power off pin $poweroff_pin"
+
+        if [ ! "$led_pin" = "" ]; then
+            /bin/echo "Using LED pin $led_pin"
+
+            /bin/echo $led_pin > /sys/class/gpio/export
+            /bin/echo out > /sys/class/gpio/gpio$led_pin/direction
+
+            for iteration in 1 2 3; do
+                /bin/echo 0 > /sys/class/gpio/gpio$led_pin/value
+                /bin/sleep 0.2
+                /bin/echo 1 > /sys/class/gpio/gpio$led_pin/value
+                /bin/sleep 0.2
+            done
+        fi
+
+        /bin/echo $poweroff_pin > /sys/class/gpio/export
+        /bin/echo out > /sys/class/gpio/gpio$poweroff_pin/direction
+
+        /bin/echo 0 > /sys/class/gpio/gpio$poweroff_pin/value
+
         /bin/sleep 0.5
         ;;
 esac

--- a/daemon/usr/bin/cleanshutd
+++ b/daemon/usr/bin/cleanshutd
@@ -60,7 +60,9 @@ echo "monitoring BCM $trigger_pin"
 
 while [ $daemon = "on" ]; do
     if [ $(raspi-gpio get $trigger_pin | grep -c "level=0 fsel=0 func=INPUT") = 1 ]; then
-        echo "BCM $trigger_pin asserted low, system shutdown in $shutdown_delay minutes"
+        msg="BCM $trigger_pin asserted low, system shutdown in $shutdown_delay minutes"
+        echo $msg
+        wall $msg
         daemon="off" && shutdown -h +$shutdown_delay
         sleep $polling_rate
     fi

--- a/daemon/usr/bin/cleanshutd
+++ b/daemon/usr/bin/cleanshutd
@@ -68,6 +68,10 @@ function pin_state {
     echo $(raspi-gpio get $trigger_pin | grep -c "level=0 fsel=0 func=INPUT")
 }
 
+if [ "$trigger_pin" != "$led_pin" ]; then
+    raspi-gpio set $led_pin op dh
+fi
+
 while [ $daemon = "on" ]; do
     if [ `pin_state` = 1 ]; then
         echo "BCM $trigger_pin asserted low"
@@ -76,6 +80,10 @@ while [ $daemon = "on" ]; do
 
         while [ `pin_state` = 1 ]; do
             sleep 0.1
+            low_time=`expr $SECONDS - $start`
+            if [ $low_time -ge $hold_time ]; then
+                break
+            fi
         done
 
         low_time=`expr $SECONDS - $start`
@@ -85,9 +93,11 @@ while [ $daemon = "on" ]; do
         if [ $low_time -ge $hold_time ]; then
             echo "BCM $trigger_pin held low"
 
-            while [ `pin_state` = 1 ]; do
-                sleep 0.5
-            done
+            if [ "$led_pin" != "off" ] && [ "$led_pin" == "$trigger_pin" ]; then
+                while [ `pin_state` = 1 ]; do
+                    sleep 0.5
+                done
+            fi
 
             msg="BCM $trigger_pin held low, system shutdown in $shutdown_delay minutes"
             echo $msg

--- a/daemon/usr/bin/cleanshutd
+++ b/daemon/usr/bin/cleanshutd
@@ -37,13 +37,19 @@ if [ -f /etc/cleanshutd.conf ]; then
     pin_value=$(grep "trigger_pin" /etc/cleanshutd.conf | cut -c 13-)
     delay_value=$(grep "shutdown_delay" /etc/cleanshutd.conf | cut -c 16-)
     rate_value=$(grep "polling_rate" /etc/cleanshutd.conf | cut -c 14-)
+    led_value=$(grep "led_pin" /etc/cleanshutd.conf | cut -c 9-)
+    hold_value=$(grep "hold_time" /etc/cleanshutd.conf | cut -c 11-)
     declare -i trigger_pin=$pin_value
     declare -i shutdown_delay=$delay_value
     declare -i polling_rate=$rate_value
+    declare -i led_pin=$led_value
+    declare -i hold_time=$hold_value
 else
     declare -i trigger_pin=4
     declare -i shutdown_delay=5
     declare -i polling_rate=2
+    declare -i led_pin="off"
+    declare -i hold_time=2
 fi
 
 # Setting up pin as an input with pullup
@@ -58,12 +64,47 @@ raspi-gpio set $trigger_pin ip pu
 
 echo "monitoring BCM $trigger_pin"
 
+function pin_state {
+    echo $(raspi-gpio get $trigger_pin | grep -c "level=0 fsel=0 func=INPUT")
+}
+
 while [ $daemon = "on" ]; do
-    if [ $(raspi-gpio get $trigger_pin | grep -c "level=0 fsel=0 func=INPUT") = 1 ]; then
-        msg="BCM $trigger_pin asserted low, system shutdown in $shutdown_delay minutes"
-        echo $msg
-        wall $msg
-        daemon="off" && shutdown -h +$shutdown_delay
+    if [ `pin_state` = 1 ]; then
+        echo "BCM $trigger_pin asserted low"
+
+        start=$SECONDS
+
+        while [ `pin_state` = 1 ]; do
+            sleep 0.1
+        done
+
+        low_time=`expr $SECONDS - $start`
+
+        echo "Held low for $low_time"
+        
+        if [ $low_time -ge $hold_time ]; then
+            echo "BCM $trigger_pin held low"
+
+            while [ `pin_state` = 1 ]; do
+                sleep 0.5
+            done
+
+            msg="BCM $trigger_pin held low, system shutdown in $shutdown_delay minutes"
+            echo $msg
+            wall $msg
+
+            daemon="off" && shutdown -h +$shutdown_delay
+
+            if [ "$led_pin" != "off" ]; then
+                while true; do
+                    raspi-gpio set $led_pin op dl
+                    sleep 0.1
+                    raspi-gpio set $led_pin op dh
+                    sleep 0.1
+                done
+            fi
+
+        fi
         sleep $polling_rate
     fi
 done

--- a/setup.sh
+++ b/setup.sh
@@ -344,6 +344,19 @@ if [ "$FORCE" != '-y' ]; then
     read -r -p "What BCM pin would you like to assert for GPIO power-off? (Enter \"off\" to disable) " bcmnumber < /dev/tty
     if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
         sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=$bcmnumber|" /etc/cleanshutd.conf
+        echo
+        read -r -p "What BCM pin would you like to blink an LED before GPIO power-off? (Enter \"off\" to disable) " bcmnumber < /dev/tty
+        if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
+            sudo sed -i "s|led_pin=.*$|led_pin=$bcmnumber|" /etc/cleanshutd.conf
+        else
+            if [ "$bcmnumber" = "off" ]; then
+                sudo sed -i "s|led_pin=.*$|led_pin=off|" /etc/cleanshutd.conf
+                info "\nGPIO power-off LED functionality has been disabled. Edit /etc/cleanshutd.conf to change"
+            else
+                warning "\ninput not recognised as a valid BCM pin number!"
+                echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
+            fi
+        fi
     else
         if [ "$bcmnumber" = "off" ]; then
             sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=off|" /etc/cleanshutd.conf

--- a/setup.sh
+++ b/setup.sh
@@ -319,6 +319,7 @@ done
 
 echo -e "\nInstalling daemon..."
 
+sudo cp ./daemon/lib/systemd/system-shutdown/gpio-poweroff /lib/systemd/system-shutdown/gpio-poweroff
 sudo cp ./daemon/etc/init.d/cleanshutd /etc/init.d/
 sudo cp ./daemon/usr/bin/cleanshutd /usr/bin/
 sudo chmod +x /usr/bin/cleanshutd
@@ -338,6 +339,21 @@ if [ "$FORCE" != '-y' ]; then
         warning "\ninput not recognised as a valid BCM pin number!"
         echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
     fi
+
+    echo
+    read -r -p "What BCM pin would you like to assert for GPIO power-off? (Enter \"off\" to disable) " bcmnumber < /dev/tty
+    if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
+        sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=$bcmnumber|" /etc/cleanshutd.conf
+    else
+        if [ "$bcmnumber" = "off" ]; then
+            sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=off|" /etc/cleanshutd.conf
+            info "\nGPIO power-off functionality has been disabled. Edit /etc/cleanshutd.conf to change"
+        else
+            warning "\ninput not recognised as a valid BCM pin number!"
+            echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
+        fi
+    fi
+
 fi
 
 success "\nAll done!\n"

--- a/setup.sh
+++ b/setup.sh
@@ -340,10 +340,19 @@ done
 
 echo -e "\nInstalling daemon..."
 
-sudo cp ./daemon/lib/systemd/system-shutdown/gpio-poweroff /lib/systemd/system-shutdown/gpio-poweroff
 sudo cp ./daemon/etc/init.d/cleanshutd /etc/init.d/
 sudo cp ./daemon/usr/bin/cleanshutd /usr/bin/
 sudo chmod +x /usr/bin/cleanshutd
+
+if [ "$PRODUCT" == "onoffshim" ]; then
+    echo -e "\nInstalling GPIO Power Off support for OnOff SHIM..."
+    sudo cp ./daemon/lib/systemd/system-shutdown/gpio-poweroff /lib/systemd/system-shutdown/gpio-poweroff
+    echo
+fi
+
+function config_set {
+    sudo sed -i "s|$1=.*$|$1=$2|" /etc/cleanshutd.conf
+}
 
 sudo systemctl daemon-reload
 sudo systemctl enable cleanshutd
@@ -351,45 +360,23 @@ sudo systemctl enable cleanshutd
 echo -e "\nCopying default config to /etc/"
 sudo cp ./daemon/etc/cleanshutd.conf /etc/
 
-if [ "$FORCE" != '-y' ]; then
-    echo
-    read -r -p "What BCM pin would you like to use as trigger for the shutdown? " bcmnumber < /dev/tty
-    if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
-        sudo sed -i "s|trigger_pin=.*$|trigger_pin=$bcmnumber|" /etc/cleanshutd.conf
-    else
-        warning "\ninput not recognised as a valid BCM pin number!"
-        echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
+if [ "$PRODUCT" == "onoffshim" ]; then
+    echo -e "\nApplying default settings for OnOff SHIM..."
+    config_set trigger_pin 17
+    config_set poweroff_pin 4
+    config_set led_pin 17
+    config_set hold_time 2
+else
+    if [ "$FORCE" != '-y' ]; then
+        echo
+        read -r -p "What BCM pin would you like to use as trigger for the shutdown? " bcmnumber < /dev/tty
+        if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
+            config_set trigger_pin $bcmnumber
+        else
+            warning "\ninput not recognised as a valid BCM pin number!"
+            echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
+        fi
     fi
-
-    if [ "$PRODUCT" == "onoffshim" ]; then
-            echo
-            read -r -p "What BCM pin would you like to assert for GPIO power-off? (Enter \"off\" to disable) " bcmnumber < /dev/tty
-            if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
-                sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=$bcmnumber|" /etc/cleanshutd.conf
-                echo
-                read -r -p "What BCM pin would you like to blink an LED before GPIO power-off? (Enter \"off\" to disable) " bcmnumber < /dev/tty
-                if [ $bcmnumber -ge 4 &>/dev/null ] && [ $bcmnumber -le 27 &>/dev/null ]; then
-                    sudo sed -i "s|led_pin=.*$|led_pin=$bcmnumber|" /etc/cleanshutd.conf
-                else
-                    if [ "$bcmnumber" = "off" ]; then
-                        sudo sed -i "s|led_pin=.*$|led_pin=off|" /etc/cleanshutd.conf
-                        info "\nGPIO power-off LED functionality has been disabled. Edit /etc/cleanshutd.conf to change"
-                    else
-                        warning "\ninput not recognised as a valid BCM pin number!"
-                        echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
-                    fi
-                fi
-            else
-                if [ "$bcmnumber" = "off" ]; then
-                    sudo sed -i "s|poweroff_pin=.*$|poweroff_pin=off|" /etc/cleanshutd.conf
-                    info "\nGPIO power-off functionality has been disabled. Edit /etc/cleanshutd.conf to change"
-                else
-                    warning "\ninput not recognised as a valid BCM pin number!"
-                    echo "edit /etc/cleanshutd.conf manually to specify the correct pin"
-                fi
-            fi
-    fi
-
 fi
 
 success "\nAll done!\n"


### PR DESCRIPTION
This script attempts to add generic GPIO Power Off support, however it does require that the power off trigger is active-low.

The systemd shutdown script `gpio-poweroff` retrieves its settings from `cleanshutd.conf` and an additional block has been added to `install.sh` to set the `poweroff-pin` setting.

TODO: 

1. Add "press and hold" functionality, daemon should sleep for `hold_time` and check button state again before triggering shutdown
2. Add "blink to indicate" functionality, daemon should fire up optional `led_pin` and blink it quickly to indicate that shutdown has been triggered (to go hand-in-hand with .1)