### PR TITLE
Modify start and stop to use start-stop-daemon

### DIFF
--- a/daemon/etc/init.d/cleanshutd
+++ b/daemon/etc/init.d/cleanshutd
@@ -45,7 +45,7 @@ do_start()
 		return 1
 	fi
 	echo 'Starting...' >&2
-	su -c "$DAEMON" root
+	start-stop-daemon --background --make-pidfile --pidfile /var/run/cleanshutd.pid --startas /usr/bin/cleanshutd --start
 }
 
 #
@@ -58,7 +58,7 @@ do_stop()
 		return 1
 	fi
 	echo 'Stopping...' >&2
-	kill $(cat "$PIDFILE")
+	start-stop-daemon --remove-pidfile --pidfile /var/run/cleanshutd.pid --stop
 	echo 'Service stopped!' >&2
 	return 0
 }


### PR DESCRIPTION
Currently, the start command never forks, so it never returns, and just times out after 5 minutes. This PR changes the init script to use the dpkg provided start-stop-daemon. 

```
neil@raspberrypi:~ $ sudo systemctl status cleanshutd
● cleanshutd.service - LSB: Monitoring GPIO shutdown trigger
   Loaded: loaded (/etc/init.d/cleanshutd)
   Active: failed (Result: timeout) since Sat 2017-07-15 19:52:57 UTC; 51s ago
  Process: 3685 ExecStart=/etc/init.d/cleanshutd start (code=killed, signal=TERM)

Jul 15 19:47:57 raspberrypi cleanshutd[3685]: Starting...
Jul 15 19:47:57 raspberrypi su[3689]: Successful su for root by root
Jul 15 19:47:57 raspberrypi su[3689]: + ??? root:root
Jul 15 19:47:57 raspberrypi su[3689]: pam_unix(su:session): session opened for user root by (uid=0)
Jul 15 19:47:57 raspberrypi cleanshutd[3685]: monitoring BCM 4
Jul 15 19:52:57 raspberrypi systemd[1]: cleanshutd.service start operation timed out. Terminating.
Jul 15 19:52:57 raspberrypi systemd[1]: Failed to start LSB: Monitoring GPIO shutdown trigger.
Jul 15 19:52:57 raspberrypi systemd[1]: Unit cleanshutd.service entered failed state.
```