### PR TITLE
Fix for configuration issues introduced in #6

### DIFF
--- a/daemon/etc/cleanshutd.conf
+++ b/daemon/etc/cleanshutd.conf
@@ -1,4 +1,12 @@
-# config for cleanshutd (commented out values are the defaults)
+# Config for cleanshutd
+# Commented out values will be reverted to defaults,
+# and may not work on any given board.
+
+# OnOff SHIM uses trigger 17 and poweroff 4
+# Zero Lipo uses trigger 4 and poweroff off
+# pHAT BEAT uses trigger 12 and powerof off
+# Default values are trigger 4 and poweroff off
+
 #daemon_active=1
 #trigger_pin=4
 #led_pin=off

--- a/setup.sh
+++ b/setup.sh
@@ -166,9 +166,9 @@ apt_pkg_install() {
 
 config_set() {
     if [ -n $defaultconf ]; then
-        sudo sed -i "s|$1=.*$|$1=$2|" $defaultconf
+        sudo sed -i "s|#\?$1=.*$|$1=$2|" $defaultconf
     else
-        sudo sed -i "s|$1=.*$|$1=$2|" $3
+        sudo sed -i "s|#\?$1=.*$|$1=$2|" $3
     fi
 }
 


### PR DESCRIPTION
This updates the `setup.sh` script to support commented-out lines and documents the default pins used for various supported add-ons in the `cleanshutd.conf` to, hopefully, avoid any future confusion.

Fixes #21